### PR TITLE
Revert "Bump follow-redirects from 1.14.1 to 1.15.9 in /code/src/AttendeeSite in the npm_and_yarn group across 1 directory"

### DIFF
--- a/code/src/AttendeeSite/package-lock.json
+++ b/code/src/AttendeeSite/package-lock.json
@@ -419,9 +419,9 @@
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
     },
     "form-data": {
       "version": "2.5.2",


### PR DESCRIPTION
Reverts Juantrox0608/skills-secure-repository-supply-chain#3